### PR TITLE
add: option to skip changing stuff when editing a config

### DIFF
--- a/src/entities/bootconfig/BoatConfig.java
+++ b/src/entities/bootconfig/BoatConfig.java
@@ -20,11 +20,6 @@ public class BoatConfig
         this.boat_type = boat_type;
     }
 
-    public String get_boat_type()
-    {
-        return this.boat_type;
-    }
-
     public void print_all_options()
     {
         for(CategoryBase category : categories.values())
@@ -53,5 +48,25 @@ public class BoatConfig
     public <T extends CategoryBase> T get_category(final String category_name, Class<T> category_class)
     {
         return category_class.cast(categories.get(category_name));
+    }
+
+    public void set_boat_type(final String boat_type)
+    {
+        this.boat_type = boat_type;
+    }
+
+    public void set_boat_name(final String boat_name)
+    {
+        this.boat_name = boat_name;
+    }
+
+    public String get_boat_name()
+    {
+        return this.boat_name;
+    }
+
+    public String get_boat_type()
+    {
+        return this.boat_type;
     }
 }

--- a/src/managers/BoatManager.java
+++ b/src/managers/BoatManager.java
@@ -129,46 +129,67 @@ public class BoatManager {
                 input -> input,
                 input -> !input.isEmpty() && contains_boat_config(input));
 
-        System.out.printf("Boot type: %s%n", loaded_boat_configurations.get(configuration_name).get_boat_type());
-        System.out.print("Wilt u het type aanpassen (j/n)? ");
-
-        String boat_type;
-        if (scanner.nextLine().equals("n"))
-            boat_type = loaded_boat_configurations.get(configuration_name).get_boat_type();
-        else
-            boat_type = InputValidators.request_valid_input("Voer nieuw boot type in: ",
+        // Change boat name directly if wanted
+        System.out.printf("Boot naam: %s%n", loaded_boat_configurations.get(configuration_name).get_boat_name());
+        System.out.print("Wilt u de boot naam aanpassen? (j/n): ");
+        if (scanner.nextLine().equals("j"))
+        {
+            final String boat_name = InputValidators.request_valid_input("Voer nieuw boot naam in: ",
                     String::trim,
                     input -> !input.isEmpty());
 
-        final BoatConfig new_boat_config = new BoatConfig(configuration_name, boat_type);
+            loaded_boat_configurations.get(configuration_name).set_boat_name(boat_name);
+        }
 
-        System.out.println("\nDe huidige opties:");
+        // Change boat type directly if wanted
+        System.out.printf("Boot type: %s%n", loaded_boat_configurations.get(configuration_name).get_boat_type());
+        System.out.print("Wilt u het boot type aanpassen? (j/n): ");
+        if (scanner.nextLine().equals("j"))
+        {
+            final String boat_type = InputValidators.request_valid_input("Voer nieuw boot type in: ",
+                    String::trim,
+                    input -> !input.isEmpty());
+
+            loaded_boat_configurations.get(configuration_name).set_boat_type(boat_type);
+        }
+
+        System.out.println("De nieuwe waardes zijn:");
+        System.out.printf("Boot naam: %s%n", loaded_boat_configurations.get(configuration_name).get_boat_name());
+        System.out.printf("Boot type: %s%n", loaded_boat_configurations.get(configuration_name).get_boat_type());
+
+        System.out.println("\nDe huidige opties in de config zijn:");
         loaded_boat_configurations.get(configuration_name).print_all_options();
 
         boolean behouden = InputValidators.request_valid_input(
-                "Wilt u deze opties behouden (j/n)?",
+                "Weet u zeker dat u deze configuratie opnieuw wil instellen? (j/n): ",
                 String::trim,
                 input -> input.matches("^[jn]$")
-        ).equals("j");
+        ).equals("n");
 
-        if (!behouden) {
-            System.out.println("\nSelecteer welke u wilt behouden:");
+        // In case that's all, return and don't change anything else.
+        if (behouden)
+            return;
 
-            Map<String, List<String>> chosen_options = new HashMap<>();
-            request_options(chosen_options, new_boat_config);
+        final BoatConfig new_boat_config = new BoatConfig(configuration_name,
+                loaded_boat_configurations.get(configuration_name).get_boat_type()
+        );
 
-            for (final String optional_category : kOptionalCategories) {
-                if (chosen_options.containsKey(optional_category)) {
-                    switch (optional_category) {
-                        case "Uiterlijk":
-                            new_boat_config.add_category("Uiterlijk", new AppearancePart(chosen_options.get("Uiterlijk"), 0.0));
-                            break;
-                        case "Extras":
-                            new_boat_config.add_category("Extras", new ExtrasPart(chosen_options.get("Extras"), 0.0));
-                            break;
-                        default:
-                            throw new RuntimeException("Make sure to keep this up-to-date!");
-                    }
+        System.out.println("\nSelecteer nu de nieuwe opties:");
+
+        Map<String, List<String>> chosen_options = new HashMap<>();
+        request_options(chosen_options, new_boat_config);
+
+        for (final String optional_category : kOptionalCategories) {
+            if (chosen_options.containsKey(optional_category)) {
+                switch (optional_category) {
+                    case "Uiterlijk":
+                        new_boat_config.add_category("Uiterlijk", new AppearancePart(chosen_options.get("Uiterlijk"), 0.0));
+                        break;
+                    case "Extras":
+                        new_boat_config.add_category("Extras", new ExtrasPart(chosen_options.get("Extras"), 0.0));
+                        break;
+                    default:
+                        throw new RuntimeException("Make sure to keep this up-to-date!");
                 }
             }
         }

--- a/src/managers/BoatManager.java
+++ b/src/managers/BoatManager.java
@@ -145,23 +145,30 @@ public class BoatManager {
         System.out.println("\nDe huidige opties:");
         loaded_boat_configurations.get(configuration_name).print_all_options();
 
-        // TODO: Make the below code more user-friendly. The exact way to do this might need to be discussed.
-        System.out.println("\nSelecteer welke u wilt behouden:");
+        boolean behouden = InputValidators.request_valid_input(
+                "Wilt u deze opties behouden (j/n)?",
+                String::trim,
+                input -> input.matches("^[jn]$")
+        ).equals("j");
 
-        Map<String, List<String>> chosen_options = new HashMap<>();
-        request_options(chosen_options, new_boat_config);
+        if (!behouden) {
+            System.out.println("\nSelecteer welke u wilt behouden:");
 
-        for (final String optional_category : kOptionalCategories) {
-            if (chosen_options.containsKey(optional_category)) {
-                switch (optional_category) {
-                    case "Uiterlijk":
-                        new_boat_config.add_category("Uiterlijk", new AppearancePart(chosen_options.get("Uiterlijk"), 0.0));
-                        break;
-                    case "Extras":
-                        new_boat_config.add_category("Extras", new ExtrasPart(chosen_options.get("Extras"), 0.0));
-                        break;
-                    default:
-                        throw new RuntimeException("Make sure to keep this up-to-date!");
+            Map<String, List<String>> chosen_options = new HashMap<>();
+            request_options(chosen_options, new_boat_config);
+
+            for (final String optional_category : kOptionalCategories) {
+                if (chosen_options.containsKey(optional_category)) {
+                    switch (optional_category) {
+                        case "Uiterlijk":
+                            new_boat_config.add_category("Uiterlijk", new AppearancePart(chosen_options.get("Uiterlijk"), 0.0));
+                            break;
+                        case "Extras":
+                            new_boat_config.add_category("Extras", new ExtrasPart(chosen_options.get("Extras"), 0.0));
+                            break;
+                        default:
+                            throw new RuntimeException("Make sure to keep this up-to-date!");
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Overview

## Changes:
Be precise and detailed.
- added the option to skip making changes to a boat-config

## Any changes on files besides the ones directly connected to your feature/change (emtpy if none):
E.g. if you integrated your feature into another interface, said change should be listed here.
- *insert here*

## Additional Notes:
Anything else one should know about this pull request.
- *insert here*

</br>

# Tests:
- [ ] Create quotation  
- [ ] View all quotation  
- [ ] Modify quotation  
- [ ] Remove quotation  
- [ ] Export quotation  

# Extra
- [ ] Add explanation/information on wiki page
